### PR TITLE
Put igor and jenkins under "services"

### DIFF
--- a/deb-config/spinnaker/config/spinnaker-local.yml
+++ b/deb-config/spinnaker/config/spinnaker-local.yml
@@ -42,12 +42,12 @@ providers:
 
     defaultKeyPairTemplate: "spinnaker-default-keypair"
 
+services:
+  igor:
+    enabled: true
 
-igor:
-  enabled: true
 
-
-jenkins:
+  jenkins:
     enabled: ${services.igor.enabled:false}
     defaultMaster:
       name: Jenkins Builder


### PR DESCRIPTION
Makes the example line up with the current Getting Started documentation (although note the jenkins data will still need to be updated to match the user's info)